### PR TITLE
Allow configuring login API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Proyecto de formulario de inicio de sesión
+
+Este proyecto ofrece un formulario sencillo que envía las credenciales al endpoint `/api/login`.
+
+## Instrucciones de despliegue
+
+1. Sirve el contenido estático de este repositorio desde el origen deseado.
+2. Abre `index.html` y localiza el formulario con el atributo `data-api-base`.
+3. Establece `data-api-base` con la URL base del servidor de API, por ejemplo:
+   ```html
+   <form id="login-form" data-api-path="/api/login" data-api-base="http://LGOMEZ:3000">
+   ```
+4. (Opcional) Define `data-api-base-fallback` para proporcionar una segunda URL base que se usará si la base principal no es válida.
+5. Si no se especifica ninguna base, el código utilizará automáticamente `window.location.origin`.
+
+Con estos ajustes la aplicación podrá apuntar explícitamente a `http://LGOMEZ:3000/api/login` u otra instancia sin necesidad de modificar el código fuente de JavaScript.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ Este proyecto ofrece un formulario sencillo que envía las credenciales al endpo
 
 1. Sirve el contenido estático de este repositorio desde el origen deseado.
 2. Abre `index.html` y localiza el formulario con el atributo `data-api-base`.
-3. Establece `data-api-base` con la URL base del servidor de API, por ejemplo:
+3. Establece `data-api-base` con la URL base del servidor de API. Puedes proporcionar:
+   - La URL completa con protocolo, por ejemplo `https://api.ejemplo.com`.
+   - Un host con puerto (`LGOMEZ:3000`), en cuyo caso se asumirá `http://`.
+   - Una ruta relativa (`/proxy/api`), que se resolverá respecto al origen desde el que se sirva la página.
    ```html
    <form id="login-form" data-api-path="/api/login" data-api-base="http://LGOMEZ:3000">
    ```
-4. (Opcional) Define `data-api-base-fallback` para proporcionar una segunda URL base que se usará si la base principal no es válida.
+4. (Opcional) Define `data-api-base-fallback` para proporcionar una segunda URL base que se usará si la base principal no es válida. Se aplican las mismas reglas de normalización descritas arriba.
 5. Si no se especifica ninguna base, el código utilizará automáticamente `window.location.origin`.
 
 Con estos ajustes la aplicación podrá apuntar explícitamente a `http://LGOMEZ:3000/api/login` u otra instancia sin necesidad de modificar el código fuente de JavaScript.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,87 @@
+const DEFAULT_API_PATH = '/api/login';
+
+const buildEndpoint = (base, path) => {
+  const sanitizedBase = (base || '').trim();
+  const sanitizedPath = (path || DEFAULT_API_PATH).trim() || DEFAULT_API_PATH;
+  const ensuredBase = sanitizedBase.endsWith('/') ? sanitizedBase : `${sanitizedBase}/`;
+
+  try {
+    return new URL(sanitizedPath, ensuredBase || window.location.origin).toString();
+  } catch (error) {
+    const fallbackBase = window.location.origin.endsWith('/')
+      ? window.location.origin
+      : `${window.location.origin}/`;
+    return new URL(sanitizedPath, fallbackBase).toString();
+  }
+};
+
+const resolveApiBase = (form) => {
+  if (!form) return window.location.origin;
+
+  const candidates = [form.dataset.apiBase, form.dataset.apiBaseFallback, window.location.origin];
+  for (const candidate of candidates) {
+    if (candidate && candidate.trim().length > 0) {
+      try {
+        return new URL(candidate, window.location.origin).toString().replace(/\/?$/, '/');
+      } catch (error) {
+        console.warn('No se pudo interpretar la base del API proporcionada:', candidate, error);
+      }
+    }
+  }
+  return window.location.origin.endsWith('/') ? window.location.origin : `${window.location.origin}/`;
+};
+
+const showMessage = (element, message) => {
+  if (!element) return;
+  element.textContent = typeof message === 'string' ? message : JSON.stringify(message, null, 2);
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('[data-api-path]');
+  if (!form) {
+    console.warn('No se encontró un formulario con atributo data-api-path.');
+    return;
+  }
+
+  const statusElement = document.querySelector('[data-login-status]');
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const apiBase = resolveApiBase(form);
+    const apiPath = form.dataset.apiPath || DEFAULT_API_PATH;
+    const endpoint = buildEndpoint(apiBase, apiPath);
+
+    const formData = new FormData(form);
+    const payload = Object.fromEntries(formData.entries());
+
+    showMessage(statusElement, 'Enviando credenciales...');
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const text = await response.text();
+      let parsed;
+      try {
+        parsed = JSON.parse(text);
+      } catch (_error) {
+        parsed = text;
+      }
+
+      if (response.ok) {
+        showMessage(statusElement, parsed || 'Autenticación exitosa.');
+      } else {
+        const message = parsed || `Error ${response.status}`;
+        showMessage(statusElement, message);
+      }
+    } catch (error) {
+      showMessage(statusElement, `Error al conectar con el API: ${error.message}`);
+    }
+  });
+});

--- a/app.js
+++ b/app.js
@@ -1,39 +1,96 @@
 const DEFAULT_API_PATH = '/api/login';
+const PROTOCOL_REGEX = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
+
+const ensureTrailingSlash = (value) => {
+  if (!value) return '';
+  return value.endsWith('/') ? value : `${value}/`;
+};
+
+const ensureLeadingSlash = (value) => {
+  if (!value) return '/';
+  return value.startsWith('/') ? value : `/${value}`;
+};
+
+const resolveCurrentOrigin = () => {
+  const { origin, protocol, host } = window.location;
+  if (origin && origin !== 'null') {
+    return ensureTrailingSlash(origin);
+  }
+  if (protocol && host) {
+    return ensureTrailingSlash(`${protocol}//${host}`);
+  }
+  return '';
+};
+
+const normalizeBase = (value) => {
+  const trimmed = (value || '').trim();
+  if (!trimmed) return '';
+
+  if (PROTOCOL_REGEX.test(trimmed)) {
+    return ensureTrailingSlash(trimmed);
+  }
+
+  if (trimmed.startsWith('//')) {
+    const protocol = window.location.protocol || 'https:';
+    return ensureTrailingSlash(`${protocol}${trimmed}`);
+  }
+
+  if (trimmed.startsWith('/')) {
+    const origin = resolveCurrentOrigin();
+    if (!origin) return '';
+    const url = new URL(trimmed, origin);
+    return ensureTrailingSlash(url.toString());
+  }
+
+  return ensureTrailingSlash(`http://${trimmed}`);
+};
 
 const buildEndpoint = (base, path) => {
-  const sanitizedBase = (base || '').trim();
-  const sanitizedPath = (path || DEFAULT_API_PATH).trim() || DEFAULT_API_PATH;
-  const ensuredBase = sanitizedBase.endsWith('/') ? sanitizedBase : `${sanitizedBase}/`;
+  const origin = resolveCurrentOrigin();
+  const normalizedBase = normalizeBase(base) || origin;
+  const sanitizedPath = ensureLeadingSlash((path || DEFAULT_API_PATH).trim() || DEFAULT_API_PATH);
 
   try {
-    return new URL(sanitizedPath, ensuredBase || window.location.origin).toString();
+    return new URL(sanitizedPath, normalizedBase || origin).toString();
   } catch (error) {
-    const fallbackBase = window.location.origin.endsWith('/')
-      ? window.location.origin
-      : `${window.location.origin}/`;
-    return new URL(sanitizedPath, fallbackBase).toString();
+    console.warn('Fallo al componer la URL del endpoint, usando el origen actual como respaldo:', error);
+    const fallback = origin || 'http://localhost/';
+    return new URL(sanitizedPath, ensureTrailingSlash(fallback)).toString();
   }
 };
 
 const resolveApiBase = (form) => {
-  if (!form) return window.location.origin;
+  const origin = resolveCurrentOrigin();
+  if (!form) return origin;
 
-  const candidates = [form.dataset.apiBase, form.dataset.apiBaseFallback, window.location.origin];
+  const candidates = [form.dataset.apiBase, form.dataset.apiBaseFallback];
   for (const candidate of candidates) {
-    if (candidate && candidate.trim().length > 0) {
+    const normalized = normalizeBase(candidate);
+    if (normalized) {
       try {
-        return new URL(candidate, window.location.origin).toString().replace(/\/?$/, '/');
+        return ensureTrailingSlash(new URL('.', normalized).toString());
       } catch (error) {
         console.warn('No se pudo interpretar la base del API proporcionada:', candidate, error);
       }
     }
   }
-  return window.location.origin.endsWith('/') ? window.location.origin : `${window.location.origin}/`;
+
+  return origin;
 };
 
-const showMessage = (element, message) => {
-  if (!element) return;
-  element.textContent = typeof message === 'string' ? message : JSON.stringify(message, null, 2);
+const formatStatusMessage = (message, endpoint) => {
+  const lines = [];
+  if (endpoint) {
+    lines.push(`Endpoint en uso: ${endpoint}`);
+  }
+  if (message !== undefined && message !== null) {
+    if (typeof message === 'string') {
+      lines.push(message);
+    } else {
+      lines.push(JSON.stringify(message, null, 2));
+    }
+  }
+  return lines.join('\n\n');
 };
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -52,18 +109,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const apiPath = form.dataset.apiPath || DEFAULT_API_PATH;
     const endpoint = buildEndpoint(apiBase, apiPath);
 
+    if (statusElement) {
+      statusElement.textContent = formatStatusMessage('Enviando credenciales...', endpoint);
+    }
+
     const formData = new FormData(form);
     const payload = Object.fromEntries(formData.entries());
-
-    showMessage(statusElement, 'Enviando credenciales...');
 
     try {
       const response = await fetch(endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          Accept: 'application/json',
         },
         body: JSON.stringify(payload),
+        mode: 'cors',
       });
 
       const text = await response.text();
@@ -74,14 +135,18 @@ document.addEventListener('DOMContentLoaded', () => {
         parsed = text;
       }
 
-      if (response.ok) {
-        showMessage(statusElement, parsed || 'Autenticación exitosa.');
-      } else {
-        const message = parsed || `Error ${response.status}`;
-        showMessage(statusElement, message);
+      if (statusElement) {
+        if (response.ok) {
+          statusElement.textContent = formatStatusMessage(parsed || 'Autenticación exitosa.', endpoint);
+        } else {
+          const message = parsed || `Error ${response.status}`;
+          statusElement.textContent = formatStatusMessage(message, endpoint);
+        }
       }
     } catch (error) {
-      showMessage(statusElement, `Error al conectar con el API: ${error.message}`);
+      if (statusElement) {
+        statusElement.textContent = formatStatusMessage(`Error al conectar con el API: ${error.message}`, endpoint);
+      }
     }
   });
 });

--- a/index.html
+++ b/index.html
@@ -74,10 +74,12 @@
     <main>
         <h1>Iniciar sesión</h1>
         <p>
-            Ajusta el valor del atributo <code>data-api-base</code> del formulario para dirigir las peticiones a
-            otra instancia del API.
+            Ajusta el atributo <code>data-api-base</code> del formulario para dirigir las peticiones a otra instancia
+            del API. Puedes indicar la URL completa (<code>https://api.ejemplo.com</code>), un host con puerto
+            (<code>LGOMEZ:3000</code>) o incluso una ruta relativa (<code>/proxy/api</code>); el script normalizará el
+            valor y añadirá la ruta indicada en <code>data-api-path</code>.
         </p>
-        <form id="login-form" data-api-path="/api/login" data-api-base="" data-api-base-fallback="http://LGOMEZ:3000">
+        <form id="login-form" data-api-path="/api/login" data-api-base="" data-api-base-fallback="LGOMEZ:3000">
             <label>
                 Usuario
                 <input type="text" name="username" autocomplete="username" required>

--- a/index.html
+++ b/index.html
@@ -3,10 +3,93 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Formulario de inicio de sesión</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background-color: #f8f9fa;
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        main {
+            background: white;
+            border-radius: 12px;
+            padding: 2rem;
+            box-shadow: 0 20px 45px rgba(0, 0, 0, 0.1);
+            width: min(420px, 90vw);
+        }
+
+        h1 {
+            margin-top: 0;
+        }
+
+        form {
+            display: grid;
+            gap: 1rem;
+        }
+
+        label {
+            display: grid;
+            gap: 0.5rem;
+            font-weight: 600;
+        }
+
+        input {
+            border-radius: 8px;
+            border: 1px solid #ced4da;
+            padding: 0.75rem 1rem;
+            font-size: 1rem;
+        }
+
+        button {
+            padding: 0.75rem 1rem;
+            border: none;
+            border-radius: 8px;
+            background: #0d6efd;
+            color: white;
+            font-size: 1rem;
+            cursor: pointer;
+        }
+
+        button:disabled {
+            background: #6c757d;
+            cursor: not-allowed;
+        }
+
+        pre {
+            background: #f1f3f5;
+            padding: 1rem;
+            border-radius: 8px;
+            min-height: 4rem;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+    </style>
 </head>
 <body>
-    <h1>Hola Mundo</h1>
-    <p>Este es un archivo HTML de ejemplo.</p>
-    <p>Segundo parrafo</p>
+    <main>
+        <h1>Iniciar sesión</h1>
+        <p>
+            Ajusta el valor del atributo <code>data-api-base</code> del formulario para dirigir las peticiones a
+            otra instancia del API.
+        </p>
+        <form id="login-form" data-api-path="/api/login" data-api-base="" data-api-base-fallback="http://LGOMEZ:3000">
+            <label>
+                Usuario
+                <input type="text" name="username" autocomplete="username" required>
+            </label>
+            <label>
+                Contraseña
+                <input type="password" name="password" autocomplete="current-password" required>
+            </label>
+            <button type="submit">Entrar</button>
+        </form>
+        <pre data-login-status aria-live="polite"></pre>
+    </main>
+    <script src="./app.js"></script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- add a login form page that reads the API base URL from configurable data attributes
- build the login endpoint URL in JavaScript using the configured base with window.location fallback
- document how to adjust the API base for deployments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0e0eadec832f82b4b9c90fa23c85